### PR TITLE
Code and math

### DIFF
--- a/mcp_ankiconnect/ankiconnect_client.py
+++ b/mcp_ankiconnect/ankiconnect_client.py
@@ -146,6 +146,5 @@ class AnkiConnectClient:
         except Exception as e:
             raise RuntimeError(f"Error getting notes info: {str(e)}") from e
 
-
     async def close(self):
         await self.client.aclose()

--- a/mcp_ankiconnect/config.py
+++ b/mcp_ankiconnect/config.py
@@ -30,5 +30,7 @@ RATING_TO_EASE = {
 }
 
 EXCLUDE_STRINGS = [
-    "AnKing"
+    "AnKing",
+    "#AK_",
+    "!AK_"
 ]

--- a/mcp_ankiconnect/server.py
+++ b/mcp_ankiconnect/server.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Literal, Dict, Union
 import json
+import re
 import random
 import logging
 from contextlib import asynccontextmanager
@@ -231,11 +232,11 @@ async def add_note(
     tags: List[str] = Field(default_factory = list)) -> str:
     """Add a flashcard to Anki. Ensure you have looked at examples before you do this, and that you have got approval from the user to add the flashcard.
 
-    For code examples, use the xml tags <pre><code> and </code></pre> to format your code.
-    e.g. <pre><code>def fibonacci(n):
+    For code examples, use <code> tags to format your code.
+    e.g. <code>def fibonacci(n):
     if n <= 1:
         return n
-    return fibonacci(n-1) + fibonacci(n-2)</code></pre>
+    return fibonacci(n-1) + fibonacci(n-2)</code>
 
     For MathJax, use the <math> tag to format your math equations. This will automatically render the math equations in Anki.
     # e.g. <math>\frac{d}{dx}[3\sin(5x)] = 15\cos(5x)</math>
@@ -251,6 +252,10 @@ async def add_note(
     for field_name, field_value in fields.items():
         if isinstance(field_value, str):
             fields[field_name] = field_value.replace("<math>", "\\(").replace("</math>", "\\)")
+            # Replace <code> tags with <pre><code> and </code> with </code></pre>
+            fields[field_name] = field_value.replace("<code>", "<pre><code>").replace("</code>", "</code></pre>")
+            # Replace `code` tags with <pre><code> and </code></pre>
+            fields[field_name] = re.sub(r'`([^`]+)`', r'<pre><code>\1</code></pre>', fields[field_name])
 
     note = {
         "deckName": deckName,

--- a/mcp_ankiconnect/server.py
+++ b/mcp_ankiconnect/server.py
@@ -91,7 +91,12 @@ async def get_examples(
             - best_performance: Notes with less than 3 lapses
             - mature: Notes with interval greater than 21 days
             - young: Notes with interval less than 7 days
-            """
+
+        Args:
+            deck: Optional[str] - Filter by specific deck
+            limit: int - Maximum number of examples to return
+            sample: str - Sampling technique to use
+        """
         anki = AnkiConnectClient()
 
         query = "-is:suspended " + " ".join([f"-note:*{exclude_string}*" for exclude_string in EXCLUDE_STRINGS]) + " "
@@ -225,12 +230,28 @@ async def add_note(
     fields: dict[str, str],
     tags: List[str] = Field(default_factory = list)) -> str:
     """Add a flashcard to Anki. Ensure you have looked at examples before you do this, and that you have got approval from the user to add the flashcard.
+
+    For code examples, use the xml tags <pre><code> and </code></pre> to format your code.
+    e.g. <pre><code>def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)</code></pre>
+
+    For MathJax, use the <math> tag to format your math equations. This will automatically render the math equations in Anki.
+    # e.g. <math>\frac{d}{dx}[3\sin(5x)] = 15\cos(5x)</math>
+
     Args:
         deckName: str - The name of the deck to add the flashcard to.
         modelName: str - The name of the note type to use.
         fields: dict - The fields of the flashcard to add.
         tags: List[str] - The tags to add to the flashcard."""
     anki = AnkiConnectClient()
+
+    # Replace <math> tags with \( and \) in fields
+    for field_name, field_value in fields.items():
+        if isinstance(field_value, str):
+            fields[field_name] = field_value.replace("<math>", "\\(").replace("</math>", "\\)")
+
     note = {
         "deckName": deckName,
         "modelName": modelName,


### PR DESCRIPTION
Make the add_note tool documentation and parsing better for code and math. Instructs LLM to use <code> or <math> XML tags for code or mathjax, and then parses it under the hood into the format best for the code Anki plugin.

### Changes

* [`mcp_ankiconnect/server.py`](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83R234-R259): Enhanced the `add_note` function to handle `<code>` and `<math>` tags for better formatting of code examples and MathJax equations.
* [`mcp_ankiconnect/server.py`](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83R95-R99): Updated the `get_examples` method to include detailed argument descriptions.