### PR TITLE
feat: MCP tools with explicit annotations and server instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,15 @@ Every `@mcp.tool` is wrapped in `@handle_anki_connection_error` which converts e
 
 ## Tools exposed
 
-`num_cards_due_today`, `list_decks_and_notes`, `get_examples`, `fetch_due_cards_for_review`, `submit_reviews`, `add_note`, `store_media_file`, `search_notes`.
+`num_cards_due_today`, `list_decks_and_notes`, `get_examples`,
+`fetch_due_cards_for_review`, `submit_reviews`, `add_note`, `store_media_file`,
+`search_notes`, `inspect_cards`, `update_note_fields`, `update_note_tags`,
+`set_suspended`, `change_deck`, `reschedule_cards`.
 
 ## Run / debug
 
 - Run server: `uv run mcp-ankiconnect`
-- MCP Inspector (preferred for dev): `uv run mcp dev mcp_ankiconnect/server.py`
+- MCP Inspector (preferred for dev): `uv run mcp dev mcp_ankiconnect/main.py`
 - Tests: `uv run pytest` (asyncio_mode=auto, see `pyproject.toml`)
 
 Anki must be running with the AnkiConnect add-on (id `2055492159`) listening on `localhost:8765` for any integration smoke test; unit tests mock the client.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ uv sync
 You can launch the MCP Inspector via the mcp CLI:
 
 ```bash
-uv run mcp dev mcp_ankiconnect/server.py
+uv run mcp dev mcp_ankiconnect/main.py
 ```
 
 Upon launching, the Inspector will display a URL you can access in your browser to begin debugging.

--- a/mcp_ankiconnect/__init__.py
+++ b/mcp_ankiconnect/__init__.py
@@ -2,4 +2,7 @@ from .server import mcp
 from .ankiconnect_client import AnkiConnectClient
 from .config import EXCLUDE_STRINGS, RATING_TO_EASE, TIMEOUTS
 
-__all__ = ['mcp', 'AnkiConnectClient', 'EXCLUDE_STRINGS', 'RATING_TO_EASE', 'TIMEOUTS']
+# Register edit tools for package, module, and CLI import paths alike.
+from . import edit_tools as _edit_tools  # noqa: F401
+
+__all__ = ["mcp", "AnkiConnectClient", "EXCLUDE_STRINGS", "RATING_TO_EASE", "TIMEOUTS"]

--- a/mcp_ankiconnect/edit_tools.py
+++ b/mcp_ankiconnect/edit_tools.py
@@ -18,6 +18,11 @@ from mcp_ankiconnect.server import (
     handle_anki_connection_error,
     mcp,
 )
+from mcp_ankiconnect.tool_metadata import (
+    DESTRUCTIVE_IDEMPOTENT_WRITE,
+    DESTRUCTIVE_WRITE,
+    READ_ONLY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +75,7 @@ def _format_review_entry(entry: dict) -> dict:
 # --- Tools ---
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error
 async def inspect_cards(
     card_ids: list[int] | None = None,
@@ -215,7 +220,7 @@ async def inspect_cards(
         return json.dumps({"cards": out_cards}, ensure_ascii=False)
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_WRITE)
 @handle_anki_connection_error
 async def update_note_fields(
     note_id: int,
@@ -243,7 +248,7 @@ async def update_note_fields(
         return f"Updated note {note_id}. Fields modified: {field_list}."
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_IDEMPOTENT_WRITE)
 @handle_anki_connection_error
 async def update_note_tags(
     note_ids: list[int],
@@ -287,7 +292,7 @@ async def update_note_tags(
     return parts[0] + " — " + "; ".join(parts[1:]) + "."
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_IDEMPOTENT_WRITE)
 @handle_anki_connection_error
 async def set_suspended(card_ids: list[int], suspended: bool) -> str:
     """Suspend or unsuspend one or more cards.
@@ -309,7 +314,7 @@ async def set_suspended(card_ids: list[int], suspended: bool) -> str:
     return f"{verb} {len(card_ids)} card(s)."
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_WRITE)
 @handle_anki_connection_error
 async def change_deck(card_ids: list[int], deck: str) -> str:
     """Move cards into a different deck.
@@ -333,7 +338,7 @@ async def change_deck(card_ids: list[int], deck: str) -> str:
     return f"Moved {len(card_ids)} card(s) to deck '{deck}'."
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_WRITE)
 @handle_anki_connection_error
 async def reschedule_cards(
     card_ids: list[int],

--- a/mcp_ankiconnect/main.py
+++ b/mcp_ankiconnect/main.py
@@ -1,6 +1,5 @@
 import logging
 
-import mcp_ankiconnect.edit_tools  # noqa: F401  # registers edit/inspect tools
 from mcp_ankiconnect.server import mcp
 
 logger = logging.getLogger(__name__)

--- a/mcp_ankiconnect/server.py
+++ b/mcp_ankiconnect/server.py
@@ -22,11 +22,17 @@ from .config import (  # Import necessary configs
     RATING_TO_EASE,
 )
 from .server_prompts import claude_review_instructions, flashcard_guidelines
+from .tool_metadata import (
+    DESTRUCTIVE_OPEN_WORLD_WRITE,
+    DESTRUCTIVE_WRITE,
+    READ_ONLY,
+    SERVER_INSTRUCTIONS,
+)
 
 logger = logging.getLogger(__name__)
 
 logger.info("Initializing MCP-AnkiConnect server")
-mcp = FastMCP("mcp-ankiconnect")
+mcp = FastMCP("mcp-ankiconnect", instructions=SERVER_INSTRUCTIONS)
 logger.debug("Created FastMCP instance")
 
 
@@ -416,7 +422,7 @@ def _process_field_content(content: str) -> str:
 # --- Tool Definitions ---
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error  # Apply decorator
 async def num_cards_due_today(deck: str | None = None) -> str:
     """Get the number of cards due exactly today, with an optional deck filter."""
@@ -428,7 +434,7 @@ async def num_cards_due_today(deck: str | None = None) -> str:
         return f"There are {count} cards due today{deck_msg}."
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error  # Apply decorator
 async def list_decks_and_notes() -> str:
     """Get all decks (excluding specified patterns) and note types with their fields."""
@@ -480,7 +486,7 @@ async def list_decks_and_notes() -> str:
         return f"{deck_list_str}\n\n{note_types_str}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error  # Apply decorator
 async def get_examples(
     deck: str | None = None,
@@ -538,7 +544,7 @@ async def get_examples(
         return result
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error  # Apply decorator
 async def fetch_due_cards_for_review(
     deck: str | None = None,
@@ -585,7 +591,7 @@ async def fetch_due_cards_for_review(
         return review_prompt
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_WRITE)
 @handle_anki_connection_error  # Apply decorator
 async def submit_reviews(
     reviews: list[
@@ -675,7 +681,7 @@ async def submit_reviews(
         return full_response
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_OPEN_WORLD_WRITE)
 @handle_anki_connection_error  # Apply decorator
 async def add_note(
     deckName: str,
@@ -774,7 +780,7 @@ async def add_note(
             return f"SYSTEM_ERROR: {fail_message}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE_OPEN_WORLD_WRITE)
 @handle_anki_connection_error
 async def store_media_file(
     filename: str,
@@ -829,7 +835,7 @@ async def store_media_file(
             return f"SYSTEM_ERROR: Failed to store media file '{filename}'."
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @handle_anki_connection_error
 async def search_notes(
     query: str = Field(description="Anki search query string"),

--- a/mcp_ankiconnect/tool_metadata.py
+++ b/mcp_ankiconnect/tool_metadata.py
@@ -1,0 +1,55 @@
+"""Shared MCP metadata used by the server and every registered tool."""
+
+from mcp.types import ToolAnnotations
+
+
+SERVER_INSTRUCTIONS = (
+    "Use these tools to inspect and modify the user's Anki collection. Before "
+    "adding notes, identify the target deck, note type, and required fields; "
+    "call list_decks_and_notes when unknown. When creating flashcards from "
+    "supplied material, draft concise cards, check likely duplicates with "
+    "search_notes, and save with add_note. Use get_examples to match existing "
+    "style. Before editing, use search_notes to find note IDs, then call "
+    "inspect_cards(note_ids=...) to resolve card IDs and state. Report successes "
+    "and failures, including returned note IDs. "
+    "For review sessions, call fetch_due_cards_for_review before submit_reviews "
+    "and submit only ratings supplied or confirmed by the user."
+)
+
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+ADDITIVE_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+DESTRUCTIVE_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+DESTRUCTIVE_IDEMPOTENT_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+# Media inputs can read arbitrary URLs or local paths. These tools can also
+# replace an existing Anki media file when given the same filename.
+DESTRUCTIVE_OPEN_WORLD_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)

--- a/tests/test_mcp_metadata.py
+++ b/tests/test_mcp_metadata.py
@@ -1,0 +1,137 @@
+from mcp.types import ToolAnnotations
+
+from mcp_ankiconnect import mcp
+from mcp_ankiconnect.tool_metadata import ADDITIVE_WRITE, SERVER_INSTRUCTIONS
+
+
+EXPECTED_ANNOTATIONS = {
+    "num_cards_due_today": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "list_decks_and_notes": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "get_examples": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "fetch_due_cards_for_review": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "submit_reviews": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+    "add_note": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+    "store_media_file": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+    "search_notes": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "inspect_cards": ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "update_note_fields": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+    "update_note_tags": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "set_suspended": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    "change_deck": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+    "reschedule_cards": ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+}
+
+
+async def test_every_exposed_tool_has_explicit_annotations():
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+    assert tools.keys() == EXPECTED_ANNOTATIONS.keys()
+    for name, expected in EXPECTED_ANNOTATIONS.items():
+        assert tools[name].annotations == expected
+        assert all(
+            getattr(tools[name].annotations, hint) is not None
+            for hint in (
+                "readOnlyHint",
+                "destructiveHint",
+                "idempotentHint",
+                "openWorldHint",
+            )
+        )
+
+
+def test_unused_additive_profile_remains_explicit():
+    assert ADDITIVE_WRITE == ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    )
+
+
+def test_server_instructions_are_exposed_during_initialization():
+    options = mcp._mcp_server.create_initialization_options()
+
+    assert options.instructions == SERVER_INSTRUCTIONS
+    first_512_characters = SERVER_INSTRUCTIONS[:512]
+    for phrase in (
+        "target deck",
+        "note type",
+        "required fields",
+        "search_notes",
+        "add_note",
+    ):
+        assert phrase in first_512_characters
+    assert "fetch_due_cards_for_review" in SERVER_INSTRUCTIONS
+    assert "submit_reviews" in SERVER_INSTRUCTIONS
+    assert "inspect_cards(note_ids=...)" in SERVER_INSTRUCTIONS
+    assert "successes and failures" in SERVER_INSTRUCTIONS


### PR DESCRIPTION
This pull request introduces explicit tool metadata annotations to all MCP-AnkiConnect tools, improves server initialization instructions, and adds comprehensive tests to ensure these annotations are correctly applied. The main goal is to provide clear, machine-readable metadata about each tool's behavior (such as whether it is read-only or destructive), which improves safety, documentation, and integration with clients.

**Tool annotation and metadata improvements:**

* Added a new `tool_metadata.py` module defining shared annotation profiles (`READ_ONLY`, `DESTRUCTIVE_WRITE`, etc.) and a `SERVER_INSTRUCTIONS` string for consistent tool guidance.
* Updated all tool definitions in `edit_tools.py` and `server.py` to use explicit `annotations` parameters, specifying their read/write/destructive/idempotent/open-world properties. [[1]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL73-R78) [[2]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL218-R223) [[3]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL246-R251) [[4]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL290-R295) [[5]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL312-R317) [[6]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdL336-R341) [[7]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L419-R425) [[8]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L431-R437) [[9]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L483-R489) [[10]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L541-R547) [[11]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L588-R594) [[12]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L678-R684) [[13]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L777-R783) [[14]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83L832-R838)
* Updated imports and initialization to register and expose these tool annotations throughout the package. [[1]](diffhunk://#diff-bfb774db14cac68c8f85b28499e9bfc6d2a1d0170f9ff5c5cdef70524ab4a764L5-R8) [[2]](diffhunk://#diff-3d51d1096a30c5ed1ab105323f13e2a31ce5941e012dfd225751d7e14534f9cdR21-R25) [[3]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83R25-R35) [[4]](diffhunk://#diff-ea41f4e2386b510ebbac439364f7d027bd103decb58e98fabb6682766be94b96L3)

**Server instructions and documentation:**

* The MCP server now exposes detailed instructions via the `instructions` parameter, guiding clients on tool usage and best practices. [[1]](diffhunk://#diff-e30816c2e24f01c68b450e9a11f91ca355c97fee45927229f5ad512259bc6b83R25-R35) [[2]](diffhunk://#diff-01fd047d9bdef37d0af240d3470d2d1e9487c11d8acfee81332c6eb7bdf8d6c4R1-R55)
* Updated documentation in `CLAUDE.md` and `README.md` to reflect the new tool set and correct the dev entry point. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L17-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R88)

**Testing and validation:**

* Added a new test module `test_mcp_metadata.py` to verify that every exposed tool has the correct annotations, that the additive profile is explicit, and that server instructions are present during initialization.

These changes make the tool interface more robust, self-describing, and safer for both developers and automated clients.